### PR TITLE
Create MagicMirror module scaffold

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,36 +1,26 @@
-# This is a basic workflow to help you get started with Actions
+name: Module CI
 
-name: CI
-
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
-
-  # Allows you to run this workflow manually from the Actions tab
+    branches: ["main"]
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  lint:
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.DS_Store
+npm-debug.log*
+.pnpm-debug.log*

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 MMM-ideas contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MMM-ideas.css
+++ b/MMM-ideas.css
@@ -1,0 +1,22 @@
+.mmm-ideas {
+  padding: 0.5rem 1rem;
+  text-align: left;
+}
+
+.mmm-ideas.empty {
+  opacity: 0.6;
+  font-style: italic;
+}
+
+.mmm-ideas .idea {
+  font-size: 1.4rem;
+  line-height: 1.5;
+}
+
+.mmm-ideas .source {
+  margin-top: 0.4rem;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #888;
+}

--- a/MMM-ideas.js
+++ b/MMM-ideas.js
@@ -1,0 +1,120 @@
+/* global Module */
+
+Module.register("MMM-ideas", {
+  defaults: {
+    header: "Idea Spark",
+    animationSpeed: 1000,
+    updateInterval: 5 * 60 * 1000,
+    randomize: false,
+    showSource: true,
+    ideas: [
+      { text: "Take a 10 minute walk to reset your focus.", source: "Wellness" },
+      { text: "Sketch the high-level flow of a project you're planning.", source: "Planning" },
+      { text: "Write down three things you learned today.", source: "Reflection" },
+      { text: "Reach out to a teammate to discuss a new collaboration idea.", source: "Teamwork" }
+    ]
+  },
+
+  start() {
+    this.currentIndex = 0;
+    this.currentIdea = this.config.ideas.length ? this.normalizeIdea(this.config.ideas[0]) : null;
+    this.updateTimer = null;
+    this.scheduleUpdates();
+  },
+
+  getStyles() {
+    return [this.file("MMM-ideas.css")];
+  },
+
+  getTranslations() {
+    return {
+      en: "translations/en.json"
+    };
+  },
+
+  normalizeIdea(idea) {
+    if (typeof idea === "string") {
+      return { text: idea };
+    }
+
+    if (idea && typeof idea === "object" && Object.prototype.hasOwnProperty.call(idea, "text")) {
+      return {
+        text: String(idea.text),
+        source: idea.source ? String(idea.source) : null
+      };
+    }
+
+    return null;
+  },
+
+  scheduleUpdates() {
+    if (this.updateTimer) {
+      clearInterval(this.updateTimer);
+    }
+
+    if (this.config.ideas.length <= 1) {
+      return;
+    }
+
+    this.updateTimer = setInterval(() => {
+      this.currentIndex = this.getNextIndex();
+      this.currentIdea = this.normalizeIdea(this.config.ideas[this.currentIndex]);
+      this.updateDom(this.config.animationSpeed);
+    }, Math.max(this.config.updateInterval, 10 * 1000));
+  },
+
+  getNextIndex() {
+    if (!this.config.randomize) {
+      return (this.currentIndex + 1) % this.config.ideas.length;
+    }
+
+    if (this.config.ideas.length === 1) {
+      return 0;
+    }
+
+    let next = this.currentIndex;
+    while (next === this.currentIndex) {
+      next = Math.floor(Math.random() * this.config.ideas.length);
+    }
+
+    return next;
+  },
+
+  getDom() {
+    const wrapper = document.createElement("div");
+    wrapper.className = "mmm-ideas";
+
+    if (!this.currentIdea) {
+      wrapper.classList.add("empty");
+      wrapper.textContent = this.translate("NO_IDEAS");
+      return wrapper;
+    }
+
+    const ideaText = document.createElement("div");
+    ideaText.className = "idea";
+    ideaText.textContent = this.currentIdea.text;
+    wrapper.appendChild(ideaText);
+
+    if (this.config.showSource && this.currentIdea.source) {
+      const ideaSource = document.createElement("div");
+      ideaSource.className = "source";
+      ideaSource.textContent = this.currentIdea.source;
+      wrapper.appendChild(ideaSource);
+    }
+
+    return wrapper;
+  },
+
+  suspend() {
+    if (this.updateTimer) {
+      clearInterval(this.updateTimer);
+      this.updateTimer = null;
+    }
+  },
+
+  resume() {
+    if (!this.updateTimer && this.config.ideas.length > 1) {
+      this.scheduleUpdates();
+    }
+  }
+});

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# MMM-ideas
+
+A [MagicMirror²](https://magicmirror.builders/) module that surfaces short prompts and ideas to spark creativity, retrospectives, or planning discussions. Configure your own idea list and the module will rotate through them on your mirror.
+
+## Installation
+
+1. Navigate to the `modules` directory of your MagicMirror² installation:
+   ```bash
+   cd ~/MagicMirror/modules
+   ```
+2. Clone this repository:
+   ```bash
+   git clone https://github.com/your-username/MMM-ideas.git
+   ```
+3. Install dependencies (none required right now) and restart your MagicMirror² instance.
+
+## Configuration
+
+Add the module definition to the `modules` array in your `config/config.js`:
+
+```javascript
+{
+  module: "MMM-ideas",
+  position: "top_left",
+  header: "Daily Idea",
+  config: {
+    updateInterval: 2 * 60 * 1000,
+    randomize: true,
+    showSource: true,
+    ideas: [
+      { text: "Call someone you have not spoken to in a while", source: "Connections" },
+      { text: "Sketch an outline for the next team workshop", source: "Planning" },
+      { text: "List three wins from this week", source: "Reflection" }
+    ]
+  }
+}
+```
+
+### Options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `updateInterval` | `5 * 60 * 1000` | Time (in milliseconds) between idea changes. Values below 10 seconds are ignored. |
+| `animationSpeed` | `1000` | Duration of DOM update animations in milliseconds. |
+| `randomize` | `false` | If `true`, the next idea is chosen at random instead of sequential order. |
+| `showSource` | `true` | Display the optional `source` label when it is provided. |
+| `ideas` | `[]` | Array of strings or `{ text, source }` objects to display. |
+
+### Translations
+
+Currently only English (`en`) is included. Contributions for additional translations are welcome.
+
+## Development
+
+This module does not yet require a `node_helper.js`. If you plan to fetch data from external APIs or perform server-side work, create a helper and update the workflow accordingly.
+
+## License
+
+Released under the MIT License. See `LICENSE` for more details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "mmm-ideas",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mmm-ideas",
+      "version": "0.1.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "mmm-ideas",
+  "version": "0.1.0",
+  "description": "MagicMirror² module that rotates through idea prompts for inspiration and planning.",
+  "main": "MMM-ideas.js",
+  "scripts": {
+    "test": "echo 'No automated tests configured yet.'"
+  },
+  "keywords": [
+    "magicmirror",
+    "magicmirror2",
+    "module",
+    "ideas",
+    "productivity"
+  ],
+  "author": "MMM-ideas contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/your-username/MMM-ideas.git"
+  },
+  "bugs": {
+    "url": "https://github.com/your-username/MMM-ideas/issues"
+  },
+  "homepage": "https://github.com/your-username/MMM-ideas#readme"
+}

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,0 +1,3 @@
+{
+  "NO_IDEAS": "Add ideas to your configuration to get started."
+}


### PR DESCRIPTION
## Summary
- add the MMM-ideas front-end module with configurable rotating idea prompts and styling
- document installation, configuration options, and licensing for the new MagicMirror² module
- configure npm metadata and CI workflow to run the module's placeholder test command

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1a72f5d1c832e8d1e4aa7a7870731