### PR TITLE
Add UEFA Champions League standings module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/MMM-UCLStandings/LICENSE
+++ b/MMM-UCLStandings/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 MMM-UCLStandings Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MMM-UCLStandings/MMM-UCLStandings.css
+++ b/MMM-UCLStandings/MMM-UCLStandings.css
@@ -1,0 +1,41 @@
+.ucl-standings-wrapper {
+  text-align: left;
+}
+
+.ucl-standings {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.ucl-standings thead th {
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  text-transform: uppercase;
+  font-size: 0.8em;
+  letter-spacing: 0.08em;
+}
+
+.ucl-standings tbody td {
+  padding: 0.2rem 0.5rem;
+}
+
+.ucl-standings tbody tr:nth-child(odd) {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.ucl-standings tbody tr:nth-child(even) {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.ucl-team-name {
+  text-align: left;
+  white-space: nowrap;
+}
+
+.ucl-number {
+  text-align: right;
+}
+
+.ucl-error {
+  color: #ff5722;
+}

--- a/MMM-UCLStandings/MMM-UCLStandings.js
+++ b/MMM-UCLStandings/MMM-UCLStandings.js
@@ -1,0 +1,187 @@
+/* MagicMirror² Module: MMM-UCLStandings
+ * Fetches and displays the latest UEFA Champions League league standings.
+ *
+ * By OpenAI's ChatGPT
+ * MIT Licensed.
+ */
+
+Module.register("MMM-UCLStandings", {
+  defaults: {
+    updateInterval: 6 * 60 * 60 * 1000, // 6 hours
+    animationSpeed: 1000,
+    maxTeams: 12,
+    showCountry: false,
+    dataUrl:
+      "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/uefa.cl.json"
+  },
+
+  requiresVersion: "2.1.0",
+
+  start() {
+    this.standings = [];
+    this.loaded = false;
+    this.error = null;
+    this.updateTimer = null;
+
+    this.sendSocketNotification("UCL_CONFIG", this.config);
+    this.scheduleUpdate(0);
+  },
+
+  stop() {
+    if (this.updateTimer) {
+      clearTimeout(this.updateTimer);
+    }
+  },
+
+  getTranslations() {
+    return {
+      en: "translations/en.json"
+    };
+  },
+
+  getStyles() {
+    return ["MMM-UCLStandings.css"];
+  },
+
+  scheduleUpdate(delay) {
+    const nextLoad = typeof delay === "number" ? delay : this.config.updateInterval;
+
+    if (this.updateTimer) {
+      clearTimeout(this.updateTimer);
+    }
+
+    this.updateTimer = setTimeout(() => {
+      this.sendSocketNotification("UCL_GET_STANDINGS");
+    }, Math.max(nextLoad, 0));
+  },
+
+  socketNotificationReceived(notification, payload) {
+    if (notification === "UCL_STANDINGS") {
+      this.error = null;
+      this.standings = Array.isArray(payload) ? payload : [];
+      this.loaded = true;
+      this.updateDom(this.config.animationSpeed);
+      this.scheduleUpdate();
+    } else if (notification === "UCL_ERROR") {
+      this.error = payload || { message: "Unknown error" };
+      this.standings = [];
+      this.loaded = true;
+      this.updateDom(this.config.animationSpeed);
+      this.scheduleUpdate();
+    }
+  },
+
+  getDom() {
+    const wrapper = document.createElement("div");
+    wrapper.className = "ucl-standings-wrapper";
+
+    if (!this.loaded) {
+      wrapper.innerHTML = this.translate("LOADING");
+      wrapper.classList.add("dimmed", "light", "small");
+      return wrapper;
+    }
+
+    if (this.error) {
+      wrapper.innerHTML = `${this.translate("ERROR")}: ${this.error.message || this.error}`;
+      wrapper.classList.add("bright", "small", "ucl-error");
+      return wrapper;
+    }
+
+    if (!this.standings.length) {
+      wrapper.innerHTML = this.translate("NO_DATA");
+      wrapper.classList.add("dimmed", "light", "small");
+      return wrapper;
+    }
+
+    const table = document.createElement("table");
+    table.className = "small ucl-standings";
+
+    table.appendChild(this.createTableHeader());
+    table.appendChild(this.createTableBody());
+
+    wrapper.appendChild(table);
+    return wrapper;
+  },
+
+  createTableHeader() {
+    const thead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+
+    const headers = [
+      "#",
+      this.translate("TEAM"),
+      this.translate("MP"),
+      this.translate("W"),
+      this.translate("D"),
+      this.translate("L"),
+      this.translate("GF"),
+      this.translate("GA"),
+      this.translate("GD"),
+      this.translate("PTS")
+    ];
+
+    headers.forEach((label) => {
+      const th = document.createElement("th");
+      th.innerHTML = label;
+      headerRow.appendChild(th);
+    });
+
+    thead.appendChild(headerRow);
+    return thead;
+  },
+
+  createTableBody() {
+    const tbody = document.createElement("tbody");
+
+    const maxTeams =
+      typeof this.config.maxTeams === "number" && this.config.maxTeams > 0
+        ? Math.min(this.config.maxTeams, this.standings.length)
+        : this.standings.length;
+
+    for (let i = 0; i < maxTeams; i += 1) {
+      const team = this.standings[i];
+      const row = document.createElement("tr");
+
+      const columns = [
+        i + 1,
+        this.formatTeamName(team.name),
+        team.played,
+        team.wins,
+        team.draws,
+        team.losses,
+        team.goalsFor,
+        team.goalsAgainst,
+        team.goalDifference,
+        team.points
+      ];
+
+      columns.forEach((value, index) => {
+        const cell = document.createElement("td");
+        cell.innerHTML = value;
+        if (index === 1) {
+          cell.classList.add("ucl-team-name");
+        } else {
+          cell.classList.add("ucl-number");
+        }
+        row.appendChild(cell);
+      });
+
+      tbody.appendChild(row);
+    }
+
+    return tbody;
+  },
+
+  formatTeamName(name) {
+    if (this.config.showCountry || typeof name !== "string") {
+      return name;
+    }
+
+    const countryIndex = name.lastIndexOf(" (");
+    if (countryIndex > 0 && name.endsWith(")")) {
+      return name.substring(0, countryIndex);
+    }
+
+    return name;
+  }
+});

--- a/MMM-UCLStandings/README.md
+++ b/MMM-UCLStandings/README.md
@@ -1,0 +1,51 @@
+# MMM-UCLStandings
+
+A [MagicMirror²](https://magicmirror.builders/) module that fetches and displays the latest UEFA Champions League league standings. The module uses the open football dataset maintained on GitHub and derives the table from recorded match results.
+
+> ⚠️ The GitHub dataset is updated shortly after matches are completed. Standings may lag behind live results by a few hours.
+
+## Installation
+
+```bash
+cd ~/MagicMirror/modules
+git clone https://github.com/your-username/MMM-UCLStandings.git
+cd MMM-UCLStandings
+npm install
+```
+
+## Configuration
+
+Add the module to the `modules` array in your `config/config.js`:
+
+```javascript
+{
+  module: "MMM-UCLStandings",
+  position: "top_left",
+  config: {
+    maxTeams: 12,
+    updateInterval: 3 * 60 * 60 * 1000 // every 3 hours
+  }
+}
+```
+
+### Options
+
+| Option | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| `updateInterval` | `number` | `21600000` (6 hours) | How often the standings should be refreshed. |
+| `animationSpeed` | `number` | `1000` | Animation speed (ms) used when updating the DOM. |
+| `maxTeams` | `number` | `12` | Limit the number of teams displayed. Set to `0` or omit to show all 36 teams. |
+| `showCountry` | `boolean` | `false` | Keep the country abbreviation in team names (e.g. `FC Barcelona (ESP)`). |
+| `dataUrl` | `string` | Dataset URL | Override the data source. Useful if you maintain your own mirror of the dataset. |
+| `fetchTimeout` | `number` | `10` | Timeout (in seconds) for the HTTP request. |
+| `proxy` | `string` | `process.env.HTTPS_PROXY` | Optional proxy URL. Defaults to the `HTTP(S)_PROXY` environment variables when not provided. |
+
+## Development
+
+- `npm install` – Install dependencies.
+- The module is written in CommonJS to match the MagicMirror² runtime.
+- Data is sourced from [openfootball/football.json](https://github.com/openfootball/football.json).
+
+## License
+
+[MIT](LICENSE)

--- a/MMM-UCLStandings/node_helper.js
+++ b/MMM-UCLStandings/node_helper.js
@@ -1,0 +1,157 @@
+const NodeHelper = require("node_helper");
+const fetch = require("node-fetch");
+const { HttpsProxyAgent } = require("https-proxy-agent");
+
+const DEFAULT_URL =
+  "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/uefa.cl.json";
+
+module.exports = NodeHelper.create({
+  start() {
+    this.config = {};
+    this.proxyAgent = null;
+  },
+
+  socketNotificationReceived(notification, payload) {
+    if (notification === "UCL_CONFIG") {
+      this.config = payload || {};
+      this.configureProxy();
+      this.getStandings();
+    } else if (notification === "UCL_GET_STANDINGS") {
+      this.getStandings();
+    }
+  },
+
+  configureProxy() {
+    const proxyUrl =
+      this.config.proxy ||
+      process.env.HTTPS_PROXY ||
+      process.env.https_proxy ||
+      process.env.HTTP_PROXY ||
+      process.env.http_proxy;
+
+    if (proxyUrl) {
+      try {
+        this.proxyAgent = new HttpsProxyAgent(proxyUrl);
+      } catch (error) {
+        console.error(`MMM-UCLStandings: proxy configuration failed - ${error.message}`);
+        this.proxyAgent = null;
+      }
+    } else {
+      this.proxyAgent = null;
+    }
+  },
+
+  async getStandings() {
+    const url = this.config.dataUrl || DEFAULT_URL;
+
+    try {
+      const options = {
+        headers: {
+          "User-Agent": "MMM-UCLStandings/1.0 (+https://github.com/)",
+          Accept: "application/json"
+        },
+        timeout: (this.config.fetchTimeout || 10) * 1000
+      };
+
+      if (this.proxyAgent) {
+        options.agent = this.proxyAgent;
+      }
+
+      const response = await fetch(url, options);
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      const data = await response.json();
+      const standings = this.computeStandings(data);
+
+      this.sendSocketNotification("UCL_STANDINGS", standings);
+    } catch (error) {
+      console.error(`MMM-UCLStandings: ${error.message}`);
+      this.sendSocketNotification("UCL_ERROR", { message: error.message });
+    }
+  },
+
+  computeStandings(data) {
+    if (!data || !Array.isArray(data.matches)) {
+      return [];
+    }
+
+    const table = new Map();
+
+    const ensureTeam = (name) => {
+      if (!table.has(name)) {
+        table.set(name, {
+          name,
+          played: 0,
+          wins: 0,
+          draws: 0,
+          losses: 0,
+          goalsFor: 0,
+          goalsAgainst: 0,
+          points: 0
+        });
+      }
+      return table.get(name);
+    };
+
+    data.matches.forEach((match) => {
+      const score = match && match.score && match.score.ft;
+      if (!score || score.length !== 2) {
+        return;
+      }
+
+      const homeGoals = Number(score[0]);
+      const awayGoals = Number(score[1]);
+
+      if (!Number.isFinite(homeGoals) || !Number.isFinite(awayGoals)) {
+        return;
+      }
+
+      const homeTeam = ensureTeam(match.team1);
+      const awayTeam = ensureTeam(match.team2);
+
+      homeTeam.played += 1;
+      awayTeam.played += 1;
+
+      homeTeam.goalsFor += homeGoals;
+      homeTeam.goalsAgainst += awayGoals;
+      awayTeam.goalsFor += awayGoals;
+      awayTeam.goalsAgainst += homeGoals;
+
+      if (homeGoals > awayGoals) {
+        homeTeam.wins += 1;
+        homeTeam.points += 3;
+        awayTeam.losses += 1;
+      } else if (homeGoals < awayGoals) {
+        awayTeam.wins += 1;
+        awayTeam.points += 3;
+        homeTeam.losses += 1;
+      } else {
+        homeTeam.draws += 1;
+        awayTeam.draws += 1;
+        homeTeam.points += 1;
+        awayTeam.points += 1;
+      }
+    });
+
+    return Array.from(table.values())
+      .map((team) => ({
+        ...team,
+        goalDifference: team.goalsFor - team.goalsAgainst
+      }))
+      .sort((a, b) => {
+        if (b.points !== a.points) {
+          return b.points - a.points;
+        }
+        if (b.goalDifference !== a.goalDifference) {
+          return b.goalDifference - a.goalDifference;
+        }
+        if (b.goalsFor !== a.goalsFor) {
+          return b.goalsFor - a.goalsFor;
+        }
+        return a.name.localeCompare(b.name);
+      });
+  }
+});

--- a/MMM-UCLStandings/package-lock.json
+++ b/MMM-UCLStandings/package-lock.json
@@ -1,0 +1,104 @@
+{
+  "name": "mmm-uclstandings",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mmm-uclstandings",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.2",
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/MMM-UCLStandings/package.json
+++ b/MMM-UCLStandings/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "mmm-uclstandings",
+  "version": "1.0.0",
+  "description": "MagicMirror² module that displays UEFA Champions League standings",
+  "main": "MMM-UCLStandings.js",
+  "author": "MMM-UCLStandings Contributors",
+  "license": "MIT",
+  "keywords": [
+    "magicmirror",
+    "module",
+    "soccer",
+    "football",
+    "uefa",
+    "champions league"
+  ],
+  "dependencies": {
+    "https-proxy-agent": "^7.0.2",
+    "node-fetch": "^2.6.12"
+  }
+}

--- a/MMM-UCLStandings/translations/en.json
+++ b/MMM-UCLStandings/translations/en.json
@@ -1,0 +1,14 @@
+{
+  "LOADING": "Loading Champions League standings...",
+  "ERROR": "Error",
+  "NO_DATA": "No standings available",
+  "TEAM": "Team",
+  "MP": "MP",
+  "W": "W",
+  "D": "D",
+  "L": "L",
+  "GF": "GF",
+  "GA": "GA",
+  "GD": "GD",
+  "PTS": "Pts"
+}


### PR DESCRIPTION
## Summary
- add the MMM-UCLStandings MagicMirror² module for displaying Champions League standings
- fetch and process standings data via a node helper with proxy support
- document configuration options and ship styling, translations, and packaging metadata

## Testing
- `node - <<'NODE'
const Module = require('module');
const originalLoad = Module._load;
Module._load = function (request, parent, isMain) {
  if (request === 'node_helper') {
    return {
      create: (proto) => Object.assign({
        sendSocketNotification(notification, payload) {
          if (Array.isArray(payload)) {
            console.log(notification, payload.length);
          } else {
            console.log(notification, payload);
          }
        }
      }, proto)
    };
  }
  return originalLoad.call(this, request, parent, isMain);
};

const helper = require('./MMM-UCLStandings/node_helper.js');

helper.config = {};
helper.configureProxy();
helper
  .getStandings()
  .then(() => console.log('done'))
  .catch((error) => console.error('error', error));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68d1a98e25f4832eb6be9d07449f0e01