### PR TITLE
Convert MMM-UCLStandings into MagicMirror scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/MMM-UCLStandings/LICENSE
+++ b/MMM-UCLStandings/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 MMM-UCLStandings Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MMM-UCLStandings/MMM-UCLStandings.css
+++ b/MMM-UCLStandings/MMM-UCLStandings.css
@@ -1,0 +1,45 @@
+.ucl-standings-wrapper {
+  text-align: left;
+}
+
+.ucl-table {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ucl-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.ucl-row:nth-child(odd) {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+.ucl-row:nth-child(even) {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.ucl-position {
+  font-weight: 700;
+  margin-right: 0.75rem;
+  min-width: 1.5rem;
+}
+
+.ucl-team {
+  flex: 1 1 auto;
+  font-weight: 500;
+}
+
+.ucl-points {
+  font-variant-numeric: tabular-nums;
+  margin-left: 0.75rem;
+}
+
+.ucl-error {
+  color: #ff7043;
+}

--- a/MMM-UCLStandings/MMM-UCLStandings.js
+++ b/MMM-UCLStandings/MMM-UCLStandings.js
@@ -1,0 +1,160 @@
+/* MagicMirror² Module: MMM-UCLStandings
+ * Simple scaffold for displaying UEFA Champions League standings.
+ *
+ * By OpenAI's ChatGPT
+ * MIT Licensed.
+ */
+
+const NOTIFICATIONS = {
+  CONFIG: "UCL_CONFIG",
+  REQUEST: "UCL_REQUEST",
+  DATA: "UCL_DATA",
+  ERROR: "UCL_ERROR"
+};
+
+Module.register("MMM-UCLStandings", {
+  defaults: {
+    updateInterval: 60 * 60 * 1000, // 1 hour
+    animationSpeed: 1000
+  },
+
+  requiresVersion: "2.1.0",
+
+  start() {
+    this.loaded = false;
+    this.error = null;
+    this.standings = [];
+    this.updateTimer = null;
+
+    this.sendSocketNotification(NOTIFICATIONS.CONFIG, this.config);
+    this.scheduleUpdate(0);
+  },
+
+  stop() {
+    if (this.updateTimer) {
+      clearTimeout(this.updateTimer);
+      this.updateTimer = null;
+    }
+  },
+
+  getTranslations() {
+    return {
+      en: "translations/en.json"
+    };
+  },
+
+  getStyles() {
+    return ["MMM-UCLStandings.css"];
+  },
+
+  getHeader() {
+    return this.data.header || "UEFA Champions League";
+  },
+
+  scheduleUpdate(delay) {
+    const nextLoad = typeof delay === "number" ? delay : this.config.updateInterval;
+
+    if (this.updateTimer) {
+      clearTimeout(this.updateTimer);
+    }
+
+    this.updateTimer = setTimeout(() => {
+      this.sendSocketNotification(NOTIFICATIONS.REQUEST);
+    }, Math.max(nextLoad, 0));
+  },
+
+  socketNotificationReceived(notification, payload) {
+    if (notification === NOTIFICATIONS.DATA) {
+      this.loaded = true;
+      this.error = null;
+      this.standings = Array.isArray(payload) ? payload : [];
+      this.updateDom(this.config.animationSpeed);
+      this.scheduleUpdate();
+    } else if (notification === NOTIFICATIONS.ERROR) {
+      this.loaded = true;
+      this.error = payload;
+      this.standings = [];
+      this.updateDom(this.config.animationSpeed);
+      this.scheduleUpdate();
+    }
+  },
+
+  getDom() {
+    const wrapper = document.createElement("div");
+    wrapper.className = "ucl-standings-wrapper";
+
+    if (!this.loaded) {
+      wrapper.classList.add("dimmed", "light", "small");
+      wrapper.innerHTML = this.translate("LOADING");
+      return wrapper;
+    }
+
+    if (this.error) {
+      wrapper.classList.add("ucl-error", "small");
+      wrapper.innerHTML = `${this.translate("ERROR")}: ${this.formatError(this.error)}`;
+      return wrapper;
+    }
+
+    if (!this.standings.length) {
+      wrapper.classList.add("dimmed", "light", "small");
+      wrapper.innerHTML = this.translate("NO_DATA");
+      return wrapper;
+    }
+
+    const list = document.createElement("ul");
+    list.className = "ucl-table";
+
+    this.standings.forEach((team, index) => {
+      const row = document.createElement("li");
+      row.className = "ucl-row";
+
+      const position = document.createElement("span");
+      position.className = "ucl-position";
+      position.textContent = typeof team.position === "number" ? team.position : index + 1;
+
+      const name = document.createElement("span");
+      name.className = "ucl-team";
+      name.textContent = team.name || this.translate("UNKNOWN_TEAM");
+
+      const points = document.createElement("span");
+      points.className = "ucl-points";
+      points.textContent = this.formatNumber(team.points);
+
+      row.appendChild(position);
+      row.appendChild(name);
+      row.appendChild(points);
+      list.appendChild(row);
+    });
+
+    wrapper.appendChild(list);
+    return wrapper;
+  },
+
+  formatError(error) {
+    if (!error) {
+      return this.translate("UNKNOWN_ERROR");
+    }
+
+    if (typeof error === "string") {
+      return error;
+    }
+
+    if (typeof error.message === "string") {
+      return error.message;
+    }
+
+    return JSON.stringify(error);
+  },
+
+  formatNumber(value) {
+    if (typeof value === "number") {
+      return value.toString();
+    }
+
+    if (value === null || value === undefined) {
+      return "--";
+    }
+
+    return value;
+  }
+});

--- a/MMM-UCLStandings/README.md
+++ b/MMM-UCLStandings/README.md
@@ -1,0 +1,46 @@
+# MMM-UCLStandings
+
+A lightweight [MagicMirror²](https://magicmirror.builders/) module scaffold that demonstrates how to structure a front-end module and Node helper for displaying UEFA Champions League standings. The module ships with sample data so you can verify the end-to-end wiring before connecting it to a real data source.
+
+## Installation
+
+```bash
+cd ~/MagicMirror/modules
+git clone https://github.com/your-username/MMM-UCLStandings.git
+cd MMM-UCLStandings
+npm install
+```
+
+> The scaffold has no runtime dependencies, so `npm install` simply prepares the module folder structure.
+
+## Configuration
+
+Add the module to the `modules` array in your `config/config.js`:
+
+```javascript
+{
+  module: "MMM-UCLStandings",
+  position: "top_left",
+  config: {
+    updateInterval: 30 * 60 * 1000 // refresh every 30 minutes
+  }
+}
+```
+
+With the default configuration the module renders the bundled sample standings. Customize the configuration and module code as needed when you are ready to wire up a live API.
+
+## How the scaffold works
+
+- **Front-end (`MMM-UCLStandings.js`)** – Registers the module, schedules periodic updates, and renders a simple list of standings entries.
+- **Node helper (`node_helper.js`)** – Mimics a data fetch by returning static sample data after a short delay. Replace `sendSampleData` with the logic required for your data provider.
+- **Styling (`MMM-UCLStandings.css`)** – Applies minimal styling to the list output so you can focus on functionality first.
+
+## Adapting the scaffold
+
+1. Update the Node helper to fetch real data (for example, from an HTTP API or a local database) and emit `UCL_DATA` with the transformed standings.
+2. Extend the client-side rendering logic to show additional statistics, groups, or localized headers.
+3. Add translations by placing additional JSON files inside the `translations` directory.
+
+## License
+
+[MIT](LICENSE)

--- a/MMM-UCLStandings/node_helper.js
+++ b/MMM-UCLStandings/node_helper.js
@@ -1,0 +1,48 @@
+const NodeHelper = require("node_helper");
+
+const SAMPLE_STANDINGS = [
+  { position: 1, name: "Real Madrid CF", points: 15 },
+  { position: 2, name: "FC Bayern München", points: 12 },
+  { position: 3, name: "Manchester City FC", points: 10 },
+  { position: 4, name: "Paris Saint-Germain", points: 8 }
+];
+
+module.exports = NodeHelper.create({
+  start() {
+    this.config = {};
+    this.pendingTimer = null;
+  },
+
+  stop() {
+    this.clearPendingTimer();
+  },
+
+  socketNotificationReceived(notification, payload) {
+    if (notification === "UCL_CONFIG") {
+      this.config = payload || {};
+      this.sendSampleData();
+    } else if (notification === "UCL_REQUEST") {
+      this.sendSampleData();
+    }
+  },
+
+  sendSampleData() {
+    this.clearPendingTimer();
+
+    this.pendingTimer = setTimeout(() => {
+      const response = SAMPLE_STANDINGS.map((team) => ({
+        ...team
+      }));
+
+      this.sendSocketNotification("UCL_DATA", response);
+      this.pendingTimer = null;
+    }, 500);
+  },
+
+  clearPendingTimer() {
+    if (this.pendingTimer) {
+      clearTimeout(this.pendingTimer);
+      this.pendingTimer = null;
+    }
+  }
+});

--- a/MMM-UCLStandings/package.json
+++ b/MMM-UCLStandings/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mmm-uclstandings",
+  "version": "0.1.0",
+  "description": "MagicMirror² module scaffold for UEFA Champions League standings",
+  "main": "MMM-UCLStandings.js",
+  "author": "MMM-UCLStandings Contributors",
+  "license": "MIT",
+  "keywords": [
+    "magicmirror",
+    "module",
+    "scaffold",
+    "uefa",
+    "champions league"
+  ]
+}

--- a/MMM-UCLStandings/translations/en.json
+++ b/MMM-UCLStandings/translations/en.json
@@ -1,0 +1,7 @@
+{
+  "LOADING": "Loading sample standings...",
+  "ERROR": "Error",
+  "NO_DATA": "Waiting for standings data",
+  "UNKNOWN_TEAM": "Unknown team",
+  "UNKNOWN_ERROR": "Unexpected error"
+}


### PR DESCRIPTION
## Summary
- replace the Champions League module implementation with a lightweight scaffold that renders sample standings
- stub the node helper to emit sample data and remove unused dependencies
- refresh documentation, styling, and translations to describe the scaffold

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1a98e25f4832eb6be9d07449f0e01